### PR TITLE
Create macOS App Skeleton for OpenSCAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+.PHONY: build clean test lint format open
+
+# Default target
+all: build
+
+# Build the project
+build:
+	xcodebuild -project OpenSCADApp/OpenSCADApp.xcodeproj \
+		-scheme OpenSCADApp \
+		-configuration Debug \
+		-destination 'platform=macOS' \
+		build
+
+# Build for release
+release:
+	xcodebuild -project OpenSCADApp/OpenSCADApp.xcodeproj \
+		-scheme OpenSCADApp \
+		-configuration Release \
+		-destination 'platform=macOS' \
+		build
+
+# Clean build artifacts
+clean:
+	xcodebuild -project OpenSCADApp/OpenSCADApp.xcodeproj \
+		-scheme OpenSCADApp \
+		clean
+	rm -rf ~/Library/Developer/Xcode/DerivedData/OpenSCADApp-*
+
+# Run tests
+test:
+	xcodebuild -project OpenSCADApp/OpenSCADApp.xcodeproj \
+		-scheme OpenSCADApp \
+		-destination 'platform=macOS' \
+		test
+
+# Lint Swift files using SwiftLint (if available)
+lint:
+	@if command -v swiftlint >/dev/null 2>&1; then \
+		swiftlint lint --path OpenSCADApp/OpenSCADApp; \
+	else \
+		echo "SwiftLint not installed. Install with: brew install swiftlint"; \
+	fi
+
+# Format Swift files using swift-format (if available)
+format:
+	@if command -v swift-format >/dev/null 2>&1; then \
+		find OpenSCADApp/OpenSCADApp -name "*.swift" -exec swift-format -i {} \; ; \
+	else \
+		echo "swift-format not installed. Install with: brew install swift-format"; \
+	fi
+
+# Open project in Xcode
+open:
+	open OpenSCADApp/OpenSCADApp.xcodeproj
+
+# Archive for distribution
+archive:
+	xcodebuild -project OpenSCADApp/OpenSCADApp.xcodeproj \
+		-scheme OpenSCADApp \
+		-configuration Release \
+		-archivePath build/OpenSCADApp.xcarchive \
+		archive
+
+# Help
+help:
+	@echo "Available targets:"
+	@echo "  build    - Build the project in Debug configuration"
+	@echo "  release  - Build the project in Release configuration"
+	@echo "  clean    - Clean build artifacts"
+	@echo "  test     - Run unit tests"
+	@echo "  lint     - Lint Swift files (requires SwiftLint)"
+	@echo "  format   - Format Swift files (requires swift-format)"
+	@echo "  open     - Open project in Xcode"
+	@echo "  archive  - Create archive for distribution"
+	@echo "  help     - Show this help message"

--- a/OpenSCADApp/OpenSCADApp.xcodeproj/project.pbxproj
+++ b/OpenSCADApp/OpenSCADApp.xcodeproj/project.pbxproj
@@ -1,0 +1,499 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A11111111111111111111111 /* OpenSCADAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111112 /* OpenSCADAppApp.swift */; };
+		A11111111111111111111113 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111114 /* ContentView.swift */; };
+		A11111111111111111111115 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111116 /* Assets.xcassets */; };
+		A11111111111111111111117 /* ScadDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111118 /* ScadDocument.swift */; };
+		A11111111111111111111119 /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1111111111111111111111A /* CodeEditorView.swift */; };
+		A1111111111111111111111B /* ModelViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1111111111111111111111C /* ModelViewer.swift */; };
+		A1111111111111111111111D /* OpenSCADService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1111111111111111111111E /* OpenSCADService.swift */; };
+		A1111111111111111111111F /* DocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111120 /* DocumentView.swift */; };
+		A11111111111111111111121 /* OpenSCADServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111122 /* OpenSCADServiceTests.swift */; };
+		A11111111111111111111123 /* ScadDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11111111111111111111124 /* ScadDocumentTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A11111111111111111111125 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A11111111111111111111126 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A11111111111111111111127;
+			remoteInfo = OpenSCADApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A11111111111111111111112 /* OpenSCADAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSCADAppApp.swift; sourceTree = "<group>"; };
+		A11111111111111111111114 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A11111111111111111111116 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A11111111111111111111118 /* ScadDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScadDocument.swift; sourceTree = "<group>"; };
+		A1111111111111111111111A /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
+		A1111111111111111111111C /* ModelViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelViewer.swift; sourceTree = "<group>"; };
+		A1111111111111111111111E /* OpenSCADService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSCADService.swift; sourceTree = "<group>"; };
+		A11111111111111111111120 /* DocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentView.swift; sourceTree = "<group>"; };
+		A11111111111111111111128 /* OpenSCADApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenSCADApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A11111111111111111111129 /* OpenSCADApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenSCADApp.entitlements; sourceTree = "<group>"; };
+		A1111111111111111111112A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1111111111111111111112B /* OpenSCADAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenSCADAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A11111111111111111111122 /* OpenSCADServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSCADServiceTests.swift; sourceTree = "<group>"; };
+		A11111111111111111111124 /* ScadDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScadDocumentTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1111111111111111111112C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1111111111111111111112D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1111111111111111111112E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A11111111111111111111128 /* OpenSCADApp.app */,
+				A1111111111111111111112B /* OpenSCADAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A1111111111111111111112F = {
+			isa = PBXGroup;
+			children = (
+				A11111111111111111111130 /* OpenSCADApp */,
+				A11111111111111111111131 /* OpenSCADAppTests */,
+				A1111111111111111111112E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A11111111111111111111130 /* OpenSCADApp */ = {
+			isa = PBXGroup;
+			children = (
+				A11111111111111111111112 /* OpenSCADAppApp.swift */,
+				A11111111111111111111114 /* ContentView.swift */,
+				A11111111111111111111118 /* ScadDocument.swift */,
+				A11111111111111111111120 /* DocumentView.swift */,
+				A11111111111111111111132 /* Views */,
+				A11111111111111111111133 /* Services */,
+				A11111111111111111111116 /* Assets.xcassets */,
+				A11111111111111111111129 /* OpenSCADApp.entitlements */,
+				A1111111111111111111112A /* Info.plist */,
+			);
+			path = OpenSCADApp;
+			sourceTree = "<group>";
+		};
+		A11111111111111111111131 /* OpenSCADAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				A11111111111111111111122 /* OpenSCADServiceTests.swift */,
+				A11111111111111111111124 /* ScadDocumentTests.swift */,
+			);
+			path = OpenSCADAppTests;
+			sourceTree = "<group>";
+		};
+		A11111111111111111111132 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A1111111111111111111111A /* CodeEditorView.swift */,
+				A1111111111111111111111C /* ModelViewer.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		A11111111111111111111133 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A1111111111111111111111E /* OpenSCADService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A11111111111111111111127 /* OpenSCADApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A11111111111111111111134 /* Build configuration list for PBXNativeTarget "OpenSCADApp" */;
+			buildPhases = (
+				A11111111111111111111135 /* Sources */,
+				A1111111111111111111112C /* Frameworks */,
+				A11111111111111111111136 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenSCADApp;
+			productName = OpenSCADApp;
+			productReference = A11111111111111111111128 /* OpenSCADApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A11111111111111111111137 /* OpenSCADAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A11111111111111111111138 /* Build configuration list for PBXNativeTarget "OpenSCADAppTests" */;
+			buildPhases = (
+				A11111111111111111111139 /* Sources */,
+				A1111111111111111111112D /* Frameworks */,
+				A1111111111111111111113A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1111111111111111111113B /* PBXTargetDependency */,
+			);
+			name = OpenSCADAppTests;
+			productName = OpenSCADAppTests;
+			productReference = A1111111111111111111112B /* OpenSCADAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A11111111111111111111126 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					A11111111111111111111127 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					A11111111111111111111137 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = A11111111111111111111127;
+					};
+				};
+			};
+			buildConfigurationList = A1111111111111111111113C /* Build configuration list for PBXProject "OpenSCADApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1111111111111111111112F;
+			productRefGroup = A1111111111111111111112E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A11111111111111111111127 /* OpenSCADApp */,
+				A11111111111111111111137 /* OpenSCADAppTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A11111111111111111111136 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A11111111111111111111115 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1111111111111111111113A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A11111111111111111111135 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A11111111111111111111111 /* OpenSCADAppApp.swift in Sources */,
+				A11111111111111111111113 /* ContentView.swift in Sources */,
+				A11111111111111111111117 /* ScadDocument.swift in Sources */,
+				A11111111111111111111119 /* CodeEditorView.swift in Sources */,
+				A1111111111111111111111B /* ModelViewer.swift in Sources */,
+				A1111111111111111111111D /* OpenSCADService.swift in Sources */,
+				A1111111111111111111111F /* DocumentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A11111111111111111111139 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A11111111111111111111121 /* OpenSCADServiceTests.swift in Sources */,
+				A11111111111111111111123 /* ScadDocumentTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A1111111111111111111113B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A11111111111111111111127 /* OpenSCADApp */;
+			targetProxy = A11111111111111111111125 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A1111111111111111111113D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A1111111111111111111113E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		A1111111111111111111113F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = OpenSCADApp/OpenSCADApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = OpenSCADApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = OpenSCADApp;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openscad.OpenSCADApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A11111111111111111111140 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = OpenSCADApp/OpenSCADApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = OpenSCADApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = OpenSCADApp;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openscad.OpenSCADApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A11111111111111111111141 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openscad.OpenSCADAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenSCADApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/OpenSCADApp";
+			};
+			name = Debug;
+		};
+		A11111111111111111111142 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openscad.OpenSCADAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OpenSCADApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/OpenSCADApp";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1111111111111111111113C /* Build configuration list for PBXProject "OpenSCADApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1111111111111111111113D /* Debug */,
+				A1111111111111111111113E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A11111111111111111111134 /* Build configuration list for PBXNativeTarget "OpenSCADApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1111111111111111111113F /* Debug */,
+				A11111111111111111111140 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A11111111111111111111138 /* Build configuration list for PBXNativeTarget "OpenSCADAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A11111111111111111111141 /* Debug */,
+				A11111111111111111111142 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A11111111111111111111126 /* Project object */;
+}

--- a/OpenSCADApp/OpenSCADApp.xcodeproj/xcshareddata/xcschemes/OpenSCADApp.xcscheme
+++ b/OpenSCADApp/OpenSCADApp.xcodeproj/xcshareddata/xcschemes/OpenSCADApp.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A11111111111111111111127"
+               BuildableName = "OpenSCADApp.app"
+               BlueprintName = "OpenSCADApp"
+               ReferencedContainer = "container:OpenSCADApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A11111111111111111111137"
+               BuildableName = "OpenSCADAppTests.xctest"
+               BlueprintName = "OpenSCADAppTests"
+               ReferencedContainer = "container:OpenSCADApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A11111111111111111111127"
+            BuildableName = "OpenSCADApp.app"
+            BlueprintName = "OpenSCADApp"
+            ReferencedContainer = "container:OpenSCADApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A11111111111111111111127"
+            BuildableName = "OpenSCADApp.app"
+            BlueprintName = "OpenSCADApp"
+            ReferencedContainer = "container:OpenSCADApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/OpenSCADApp/OpenSCADApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/OpenSCADApp/OpenSCADApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OpenSCADApp/OpenSCADApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/OpenSCADApp/OpenSCADApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OpenSCADApp/OpenSCADApp/Assets.xcassets/Contents.json
+++ b/OpenSCADApp/OpenSCADApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OpenSCADApp/OpenSCADApp/ContentView.swift
+++ b/OpenSCADApp/OpenSCADApp/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "cube.transparent")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("OpenSCAD App")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/OpenSCADApp/OpenSCADApp/DocumentView.swift
+++ b/OpenSCADApp/OpenSCADApp/DocumentView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct DocumentView: View {
+    @Binding var document: ScadDocument
+    @StateObject private var openSCADService = OpenSCADService()
+    @State private var isExecuting = false
+    @State private var showError = false
+    @State private var errorMessage = ""
+    @State private var splitRatio: CGFloat = 0.5
+
+    var body: some View {
+        GeometryReader { geometry in
+            HSplitView {
+                VStack(spacing: 0) {
+                    editorHeader
+                    CodeEditorView(text: $document.text)
+                }
+                .frame(minWidth: 300)
+
+                VStack(spacing: 0) {
+                    viewerHeader
+                    ModelViewer(modelData: openSCADService.outputData, isLoading: isExecuting)
+                }
+                .frame(minWidth: 300)
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button(action: executeScript) {
+                    Label("Execute", systemImage: "play.fill")
+                }
+                .disabled(isExecuting || !openSCADService.isOpenSCADAvailable)
+                .help(openSCADService.isOpenSCADAvailable ? "Execute script (⌘R)" : "OpenSCAD not found")
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .executeScript)) { _ in
+            executeScript()
+        }
+    }
+
+    private var editorHeader: some View {
+        HStack {
+            Label("Script Editor", systemImage: "doc.text")
+                .font(.headline)
+            Spacer()
+            if !openSCADService.isOpenSCADAvailable {
+                Label("OpenSCAD not found", systemImage: "exclamationmark.triangle")
+                    .foregroundColor(.orange)
+                    .font(.caption)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+
+    private var viewerHeader: some View {
+        HStack {
+            Label("3D Preview", systemImage: "cube.transparent")
+                .font(.headline)
+            Spacer()
+            if isExecuting {
+                ProgressView()
+                    .scaleEffect(0.7)
+                Text("Rendering...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+
+    private func executeScript() {
+        guard !isExecuting else { return }
+        guard openSCADService.isOpenSCADAvailable else {
+            errorMessage = "OpenSCAD is not installed or not found in the expected locations."
+            showError = true
+            return
+        }
+
+        isExecuting = true
+
+        Task {
+            do {
+                try await openSCADService.execute(script: document.text)
+            } catch let error as OpenSCADError {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showError = true
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showError = true
+                }
+            }
+
+            await MainActor.run {
+                isExecuting = false
+            }
+        }
+    }
+}
+
+#Preview {
+    DocumentView(document: .constant(ScadDocument()))
+}

--- a/OpenSCADApp/OpenSCADApp/Info.plist
+++ b/OpenSCADApp/OpenSCADApp/Info.plist
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenSCAD App</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>scad</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string></string>
+			<key>CFBundleTypeName</key>
+			<string>OpenSCAD Script</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.openscad.scad</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2024. All rights reserved.</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>OpenSCAD Script</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>org.openscad.scad</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>scad</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>OpenSCAD Script</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.openscad.scad</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>scad</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/OpenSCADApp/OpenSCADApp/OpenSCADApp.entitlements
+++ b/OpenSCADApp/OpenSCADApp/OpenSCADApp.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
+	<array>
+		<string>/Applications/OpenSCAD.app/</string>
+		<string>/usr/local/bin/</string>
+		<string>/opt/homebrew/bin/</string>
+	</array>
+</dict>
+</plist>

--- a/OpenSCADApp/OpenSCADApp/OpenSCADAppApp.swift
+++ b/OpenSCADApp/OpenSCADApp/OpenSCADAppApp.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+@main
+struct OpenSCADAppApp: App {
+    var body: some Scene {
+        DocumentGroup(newDocument: ScadDocument()) { file in
+            DocumentView(document: file.$document)
+        }
+        .commands {
+            CommandGroup(after: .newItem) {
+                Button("Execute Script") {
+                    NotificationCenter.default.post(name: .executeScript, object: nil)
+                }
+                .keyboardShortcut("r", modifiers: .command)
+            }
+        }
+    }
+}
+
+extension Notification.Name {
+    static let executeScript = Notification.Name("executeScript")
+}

--- a/OpenSCADApp/OpenSCADApp/ScadDocument.swift
+++ b/OpenSCADApp/OpenSCADApp/ScadDocument.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+    static var scadSource: UTType {
+        UTType(importedAs: "org.openscad.scad", conformingTo: .sourceCode)
+    }
+}
+
+struct ScadDocument: FileDocument {
+    var text: String
+
+    static var readableContentTypes: [UTType] { [.scadSource, .plainText] }
+    static var writableContentTypes: [UTType] { [.scadSource, .plainText] }
+
+    init(text: String = defaultScadContent) {
+        self.text = text
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents,
+              let string = String(data: data, encoding: .utf8)
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        text = string
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        guard let data = text.data(using: .utf8) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return FileWrapper(regularFileWithContents: data)
+    }
+
+    private static var defaultScadContent: String {
+        """
+        // OpenSCAD Script
+        // Create your 3D design here
+
+        // Example: A simple cube
+        cube([10, 10, 10]);
+        """
+    }
+}

--- a/OpenSCADApp/OpenSCADApp/Services/OpenSCADService.swift
+++ b/OpenSCADApp/OpenSCADApp/Services/OpenSCADService.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Combine
+
+enum OpenSCADError: LocalizedError {
+    case notInstalled
+    case executionFailed(String)
+    case outputFileNotFound
+    case invalidOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .notInstalled:
+            return "OpenSCAD is not installed. Please install OpenSCAD from https://openscad.org"
+        case .executionFailed(let message):
+            return "OpenSCAD execution failed: \(message)"
+        case .outputFileNotFound:
+            return "Output file was not generated"
+        case .invalidOutput:
+            return "Invalid output from OpenSCAD"
+        }
+    }
+}
+
+@MainActor
+class OpenSCADService: ObservableObject {
+    @Published var outputData: Data?
+    @Published var lastError: String?
+    @Published var isOpenSCADAvailable: Bool = false
+
+    private let openSCADPaths: [String] = [
+        "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD",
+        "/usr/local/bin/openscad",
+        "/opt/homebrew/bin/openscad",
+        "/usr/bin/openscad"
+    ]
+
+    private var openSCADPath: String?
+
+    init() {
+        openSCADPath = findOpenSCAD()
+        isOpenSCADAvailable = openSCADPath != nil
+    }
+
+    private func findOpenSCAD() -> String? {
+        for path in openSCADPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = ["openscad"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            if process.terminationStatus == 0 {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                if let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !path.isEmpty {
+                    return path
+                }
+            }
+        } catch {
+            // Silently fail
+        }
+
+        return nil
+    }
+
+    func execute(script: String) async throws {
+        guard let executablePath = openSCADPath else {
+            throw OpenSCADError.notInstalled
+        }
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let inputURL = tempDir.appendingPathComponent("input_\(UUID().uuidString).scad")
+        let outputURL = tempDir.appendingPathComponent("output_\(UUID().uuidString).stl")
+
+        defer {
+            try? FileManager.default.removeItem(at: inputURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        try script.write(to: inputURL, atomically: true, encoding: .utf8)
+
+        let result = try await runOpenSCAD(
+            executablePath: executablePath,
+            inputPath: inputURL.path,
+            outputPath: outputURL.path
+        )
+
+        if !result.success {
+            throw OpenSCADError.executionFailed(result.errorOutput)
+        }
+
+        guard FileManager.default.fileExists(atPath: outputURL.path) else {
+            throw OpenSCADError.outputFileNotFound
+        }
+
+        let data = try Data(contentsOf: outputURL)
+        self.outputData = data
+    }
+
+    private func runOpenSCAD(executablePath: String, inputPath: String, outputPath: String) async throws -> (success: Bool, errorOutput: String) {
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executablePath)
+                process.arguments = ["-o", outputPath, inputPath]
+
+                let errorPipe = Pipe()
+                process.standardError = errorPipe
+                process.standardOutput = FileHandle.nullDevice
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+
+                    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                    let errorOutput = String(data: errorData, encoding: .utf8) ?? ""
+
+                    let success = process.terminationStatus == 0
+                    continuation.resume(returning: (success, errorOutput))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func clearOutput() {
+        outputData = nil
+        lastError = nil
+    }
+}

--- a/OpenSCADApp/OpenSCADApp/Views/CodeEditorView.swift
+++ b/OpenSCADApp/OpenSCADApp/Views/CodeEditorView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+import AppKit
+
+struct CodeEditorView: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? NSTextView else {
+            return scrollView
+        }
+
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.allowsUndo = true
+        textView.isRichText = false
+        textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.backgroundColor = NSColor.textBackgroundColor
+        textView.textColor = NSColor.textColor
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.delegate = context.coordinator
+
+        textView.string = text
+
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = nsView.documentView as? NSTextView else { return }
+
+        if textView.string != text {
+            let selectedRanges = textView.selectedRanges
+            textView.string = text
+            textView.selectedRanges = selectedRanges
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: CodeEditorView
+
+        init(_ parent: CodeEditorView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+        }
+    }
+}
+
+#Preview {
+    CodeEditorView(text: .constant("cube([10, 10, 10]);"))
+        .frame(width: 400, height: 300)
+}

--- a/OpenSCADApp/OpenSCADApp/Views/ModelViewer.swift
+++ b/OpenSCADApp/OpenSCADApp/Views/ModelViewer.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import SceneKit
+
+struct ModelViewer: NSViewRepresentable {
+    let modelData: Data?
+    let isLoading: Bool
+
+    func makeNSView(context: Context) -> SCNView {
+        let sceneView = SCNView()
+        sceneView.scene = SCNScene()
+        sceneView.backgroundColor = NSColor.windowBackgroundColor
+        sceneView.allowsCameraControl = true
+        sceneView.autoenablesDefaultLighting = true
+        sceneView.showsStatistics = false
+
+        setupDefaultCamera(in: sceneView.scene!)
+        setupLighting(in: sceneView.scene!)
+
+        if modelData == nil {
+            addPlaceholder(to: sceneView.scene!)
+        }
+
+        return sceneView
+    }
+
+    func updateNSView(_ nsView: SCNView, context: Context) {
+        guard let scene = nsView.scene else { return }
+
+        scene.rootNode.childNodes.filter { $0.name == "model" || $0.name == "placeholder" }
+            .forEach { $0.removeFromParentNode() }
+
+        if let data = modelData {
+            loadModel(from: data, into: scene)
+        } else if !isLoading {
+            addPlaceholder(to: scene)
+        }
+    }
+
+    private func setupDefaultCamera(in scene: SCNScene) {
+        let cameraNode = SCNNode()
+        cameraNode.camera = SCNCamera()
+        cameraNode.position = SCNVector3(x: 30, y: 30, z: 30)
+        cameraNode.look(at: SCNVector3(x: 0, y: 0, z: 0))
+        scene.rootNode.addChildNode(cameraNode)
+    }
+
+    private func setupLighting(in scene: SCNScene) {
+        let ambientLight = SCNNode()
+        ambientLight.light = SCNLight()
+        ambientLight.light?.type = .ambient
+        ambientLight.light?.intensity = 500
+        ambientLight.light?.color = NSColor.white
+        scene.rootNode.addChildNode(ambientLight)
+
+        let directionalLight = SCNNode()
+        directionalLight.light = SCNLight()
+        directionalLight.light?.type = .directional
+        directionalLight.light?.intensity = 1000
+        directionalLight.position = SCNVector3(x: 50, y: 50, z: 50)
+        directionalLight.look(at: SCNVector3(x: 0, y: 0, z: 0))
+        scene.rootNode.addChildNode(directionalLight)
+    }
+
+    private func addPlaceholder(to scene: SCNScene) {
+        let gridNode = createGrid()
+        gridNode.name = "placeholder"
+        scene.rootNode.addChildNode(gridNode)
+
+        let textNode = createWelcomeText()
+        textNode.name = "placeholder"
+        scene.rootNode.addChildNode(textNode)
+    }
+
+    private func createGrid() -> SCNNode {
+        let gridNode = SCNNode()
+
+        for i in -5...5 {
+            let lineX = SCNBox(width: 100, height: 0.1, length: 0.1, chamferRadius: 0)
+            lineX.firstMaterial?.diffuse.contents = NSColor.gray.withAlphaComponent(0.3)
+            let lineNodeX = SCNNode(geometry: lineX)
+            lineNodeX.position = SCNVector3(x: 0, y: 0, z: CGFloat(i) * 10)
+            gridNode.addChildNode(lineNodeX)
+
+            let lineZ = SCNBox(width: 0.1, height: 0.1, length: 100, chamferRadius: 0)
+            lineZ.firstMaterial?.diffuse.contents = NSColor.gray.withAlphaComponent(0.3)
+            let lineNodeZ = SCNNode(geometry: lineZ)
+            lineNodeZ.position = SCNVector3(x: CGFloat(i) * 10, y: 0, z: 0)
+            gridNode.addChildNode(lineNodeZ)
+        }
+
+        return gridNode
+    }
+
+    private func createWelcomeText() -> SCNNode {
+        let text = SCNText(string: "Run script to preview", extrusionDepth: 1)
+        text.font = NSFont.systemFont(ofSize: 3)
+        text.firstMaterial?.diffuse.contents = NSColor.secondaryLabelColor
+
+        let textNode = SCNNode(geometry: text)
+        let (min, max) = textNode.boundingBox
+        let width = max.x - min.x
+        textNode.position = SCNVector3(x: -width / 2, y: 10, z: 0)
+
+        return textNode
+    }
+
+    private func loadModel(from data: Data, into scene: SCNScene) {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("preview.stl")
+
+        do {
+            try data.write(to: tempURL)
+
+            if let loadedScene = try? SCNScene(url: tempURL, options: [
+                .createNormalsIfAbsent: true,
+                .convertToYUp: true
+            ]) {
+                for child in loadedScene.rootNode.childNodes {
+                    let modelNode = child.clone()
+                    modelNode.name = "model"
+
+                    let material = SCNMaterial()
+                    material.diffuse.contents = NSColor.systemBlue
+                    material.specular.contents = NSColor.white
+                    material.shininess = 0.5
+                    modelNode.geometry?.materials = [material]
+
+                    scene.rootNode.addChildNode(modelNode)
+                }
+            }
+
+            try? FileManager.default.removeItem(at: tempURL)
+        } catch {
+            print("Failed to load model: \(error)")
+        }
+    }
+}
+
+struct ModelViewerOverlay: View {
+    let isLoading: Bool
+
+    var body: some View {
+        if isLoading {
+            ZStack {
+                Color.black.opacity(0.3)
+                VStack {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                    Text("Rendering...")
+                        .foregroundColor(.white)
+                        .padding(.top)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ModelViewer(modelData: nil, isLoading: false)
+        .frame(width: 400, height: 400)
+}

--- a/OpenSCADApp/OpenSCADAppTests/OpenSCADServiceTests.swift
+++ b/OpenSCADApp/OpenSCADAppTests/OpenSCADServiceTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import OpenSCADApp
+
+final class OpenSCADServiceTests: XCTestCase {
+
+    @MainActor
+    func testServiceInitialization() async throws {
+        let service = OpenSCADService()
+
+        // Service should initialize without crashing
+        XCTAssertNotNil(service)
+
+        // Output should be nil initially
+        XCTAssertNil(service.outputData)
+        XCTAssertNil(service.lastError)
+    }
+
+    @MainActor
+    func testClearOutput() async throws {
+        let service = OpenSCADService()
+
+        service.clearOutput()
+
+        XCTAssertNil(service.outputData)
+        XCTAssertNil(service.lastError)
+    }
+
+    func testOpenSCADErrorDescriptions() {
+        let notInstalledError = OpenSCADError.notInstalled
+        XCTAssertNotNil(notInstalledError.errorDescription)
+        XCTAssertTrue(notInstalledError.errorDescription!.contains("not installed"))
+
+        let executionError = OpenSCADError.executionFailed("test error")
+        XCTAssertNotNil(executionError.errorDescription)
+        XCTAssertTrue(executionError.errorDescription!.contains("test error"))
+
+        let outputError = OpenSCADError.outputFileNotFound
+        XCTAssertNotNil(outputError.errorDescription)
+        XCTAssertTrue(outputError.errorDescription!.contains("not generated"))
+
+        let invalidError = OpenSCADError.invalidOutput
+        XCTAssertNotNil(invalidError.errorDescription)
+        XCTAssertTrue(invalidError.errorDescription!.contains("Invalid"))
+    }
+
+    @MainActor
+    func testExecuteWithoutOpenSCAD() async {
+        let service = OpenSCADService()
+
+        // If OpenSCAD is not available, execution should throw
+        if !service.isOpenSCADAvailable {
+            do {
+                try await service.execute(script: "cube([10, 10, 10]);")
+                XCTFail("Expected error when OpenSCAD is not installed")
+            } catch let error as OpenSCADError {
+                XCTAssertEqual(error.errorDescription, OpenSCADError.notInstalled.errorDescription)
+            } catch {
+                XCTFail("Unexpected error type: \(error)")
+            }
+        }
+    }
+}

--- a/OpenSCADApp/OpenSCADAppTests/ScadDocumentTests.swift
+++ b/OpenSCADApp/OpenSCADAppTests/ScadDocumentTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import UniformTypeIdentifiers
+@testable import OpenSCADApp
+
+final class ScadDocumentTests: XCTestCase {
+
+    func testDefaultDocumentCreation() throws {
+        let document = ScadDocument()
+
+        XCTAssertFalse(document.text.isEmpty)
+        XCTAssertTrue(document.text.contains("OpenSCAD"))
+    }
+
+    func testDocumentWithCustomText() throws {
+        let customText = "sphere(r = 5);"
+        let document = ScadDocument(text: customText)
+
+        XCTAssertEqual(document.text, customText)
+    }
+
+    func testReadableContentTypes() {
+        let types = ScadDocument.readableContentTypes
+
+        XCTAssertFalse(types.isEmpty)
+        XCTAssertTrue(types.contains(.plainText))
+    }
+
+    func testWritableContentTypes() {
+        let types = ScadDocument.writableContentTypes
+
+        XCTAssertFalse(types.isEmpty)
+        XCTAssertTrue(types.contains(.plainText))
+    }
+
+    func testScadUTType() {
+        let scadType = UTType.scadSource
+
+        XCTAssertNotNil(scadType)
+        XCTAssertTrue(scadType.conforms(to: .sourceCode))
+    }
+
+    func testDocumentTextMutation() throws {
+        var document = ScadDocument(text: "cube([5, 5, 5]);")
+
+        document.text = "sphere(r = 10);"
+
+        XCTAssertEqual(document.text, "sphere(r = 10);")
+    }
+
+    func testDocumentTextEncoding() throws {
+        let testText = "// Test with special chars: äöü ñ"
+        let document = ScadDocument(text: testText)
+
+        XCTAssertEqual(document.text, testText)
+    }
+
+    func testEmptyDocument() throws {
+        let document = ScadDocument(text: "")
+
+        XCTAssertTrue(document.text.isEmpty)
+    }
+
+    func testMultilineDocument() throws {
+        let multilineText = """
+        // First line
+        cube([10, 10, 10]);
+        // Second line
+        sphere(r = 5);
+        """
+
+        let document = ScadDocument(text: multilineText)
+
+        XCTAssertEqual(document.text, multilineText)
+        XCTAssertTrue(document.text.contains("cube"))
+        XCTAssertTrue(document.text.contains("sphere"))
+    }
+}


### PR DESCRIPTION
As a Product Manager, I want to create a basic skeleton of an OpenSCAD application for MacOS that allows users to open and save OpenSCAD scripts, execute them, and view the resulting designs. The app should be built using popular native macOS technologies like Swift or Objective-C.

Acceptance Criteria:
1. User can install the app from the Mac App Store.
2. Launching the app opens an interface for navigating open files (Open, Save).
3. The Open File interface supports the natively recognized .scad file extension.
4. User selects a .scad script to open it in the editor and execute to generate the resulting design.
5. Design output is displayed within the app window.

Parent ID (optional):

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced OpenSCAD application with integrated code editor and 3D model viewer
  * Added support for .scad file format with read/write capabilities
  * Execute scripts with Cmd-R keyboard shortcut
  * Integrated OpenSCAD execution for rendering 3D models from scripts

* **Chores**
  * Added build automation tooling for project management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->